### PR TITLE
Fix: Tweak steps and add acceptance template

### DIFF
--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -42,13 +42,25 @@ buffy:
       remove_labels:
         - "0/pre-review-checks"
         - "New Submission!"
+      add_as_assignee: true
     remove_editor:
       only: editors
-      no_editor_text: "To be decided"
     reviewers_list:
       only: editors
       sample_value: "@reviewer-login"
       add_as_assignee: false
+    add_remove_checklist:
+      - editor response
+        only: editors
+        template_file: editor_response.md
+        data_from_issue:
+          - reviewers-list
+          - author-handle
+      - package accepted
+        only: editors
+        template_file: package-accepted-template.md
+        data_from_issue:
+          - package-name
     label_command:
       - seeking_reviewers:
           only: editors


### PR DESCRIPTION
This adds a few things

1. Editor template to kick off the review
2. Acceptance template workflow to provide a customized accepted message (might need to add variables to the template).
3. Fixes a few other steps