### PR TITLE
Fix: assign editor

### DIFF
--- a/config/settings-production.yml
+++ b/config/settings-production.yml
@@ -35,7 +35,7 @@ buffy:
       template_file: welcome_message.md    
     assign_editor:
       only: editors
-      add_as_assignee: true
+      add_as_collaborator: true
       add_labels:
         - "1/editor-assigned"
       remove_labels:


### PR DESCRIPTION
This tries to use the add_as_collaborator key instead of add as assignee. this could be the issue? referencing #19 